### PR TITLE
Update feedstock for 2022.1.1, try to get a correct osx-arm64 build (…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libobjcryst" %}
-{% set version = "2022.1" %}
-{% set sha256 = "6ddafff9981cf7205589f5268a4b9b56828bd2ce2eee7accbdc5e4f51a324285" %}
+{% set version = "2022.1.1" %}
+{% set sha256 = "e0bb4213050369e1c60568c16383bdc43d80dd40758005b1c376f319641e9e59" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libobjcryst" %}
 {% set version = "2022.1.1" %}
-{% set sha256 = "e0bb4213050369e1c60568c16383bdc43d80dd40758005b1c376f319641e9e59" %}
+{% set sha256 = "68713289ab57618973c513bfd8a12ec0e5020a4cbe8e18a73fb115af0419e976" %}
 
 package:
   name: {{ name|lower }}
@@ -21,6 +21,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - scons
+    - boost
+  host:
     - boost
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libobjcryst" %}
 {% set version = "2022.1.1" %}
-{% set sha256 = "68713289ab57618973c513bfd8a12ec0e5020a4cbe8e18a73fb115af0419e976" %}
+{% set sha256 = "cdd058a586718a501f2877586dd15067954b28f5e7d03974df3eb26cdbf4b8ea" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libobjcryst" %}
 {% set version = "2022.1.1" %}
-{% set sha256 = "cdd058a586718a501f2877586dd15067954b28f5e7d03974df3eb26cdbf4b8ea" %}
+{% set sha256 = "e987f11f207a995d1b7c9dd1700126d4667c5842cf08dbb84cb9e08774d9dd72" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/sconscript.local
+++ b/recipe/sconscript.local
@@ -5,7 +5,12 @@ Import('env')
 import os
 import platform
 
+if platform.system().lower() == 'darwin' and 'CONDA_BUILD_SYSROOT' in os.environ:
+    env.AppendUnique(CPPFLAGS=['-isysroot', os.environ['CONDA_BUILD_SYSROOT']])
+    env.AppendUnique(LINKFLAGS=['-isysroot', os.environ['CONDA_BUILD_SYSROOT']])
+
 # Apply environment settings for Anaconda compilers
+env.Replace(CC=os.environ['CC'])
 env.Replace(CXX=os.environ['CXX'])
 env.MergeFlags(os.environ['CFLAGS'])
 env.MergeFlags(os.environ['CPPFLAGS'])

--- a/recipe/sconscript.local
+++ b/recipe/sconscript.local
@@ -5,14 +5,14 @@ Import('env')
 import os
 import platform
 
-if platform.system() != 'Darwin':
-    # Apply environment settings for Anaconda compilers
-    env.Replace(CXX=os.environ['CXX'])
-    env.MergeFlags(os.environ['CFLAGS'])
-    env.MergeFlags(os.environ['CPPFLAGS'])
-    env.MergeFlags(os.environ['CXXFLAGS'])
-    env.MergeFlags(os.environ['LDFLAGS'])
+# Apply environment settings for Anaconda compilers
+env.Replace(CXX=os.environ['CXX'])
+env.MergeFlags(os.environ['CFLAGS'])
+env.MergeFlags(os.environ['CPPFLAGS'])
+env.MergeFlags(os.environ['CXXFLAGS'])
+env.MergeFlags(os.environ['LDFLAGS'])
 
+if platform.system() != 'Darwin':
     # Use the default c++98 language standard
     cxxflags98 = [f for f in env['CXXFLAGS'] if not f.startswith('-std=')]
     env.Replace(CXXFLAGS=cxxflags98)

--- a/recipe/sconscript.local
+++ b/recipe/sconscript.local
@@ -5,10 +5,6 @@ Import('env')
 import os
 import platform
 
-if platform.system().lower() == 'darwin' and 'CONDA_BUILD_SYSROOT' in os.environ:
-    env.AppendUnique(CPPFLAGS=['-isysroot', os.environ['CONDA_BUILD_SYSROOT']])
-    env.AppendUnique(LINKFLAGS=['-isysroot', os.environ['CONDA_BUILD_SYSROOT']])
-
 # Apply environment settings for Anaconda compilers
 env.Replace(CC=os.environ['CC'])
 env.Replace(CXX=os.environ['CXX'])


### PR DESCRIPTION
…through cross-compilation)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [<] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a test for a new build of libobjcryst ; trying to fix the cross-compilation build for osx-arm64 which currently results in a x86-64 lib inside the osx-arm package... likely because the compilation parameters where not passed correctly.