### PR TITLE
Add more tests for ObjCryst include files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,18 +30,18 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}                       # [not win]
-    - test -f $PREFIX/include/ObjCryst/version.h                        # [not win]
-    - test -f $PREFIX/include/ObjCryst/CrystVector/CrystVector.h        # [not win]
-    - test -f $PREFIX/include/ObjCryst/ObjCryst/Crystal.h               # [not win]
-    - test -f $PREFIX/include/ObjCryst/Quirks/VFNDebug.h                # [not win]
-    - test -f $PREFIX/include/ObjCryst/RefinableObj/RefinableObj.h      # [not win]
-    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1                # [win]
-    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1            # [win]
-    - if not exist %LIBRARY_INC%\\CrystVector\\CrystVector.h exit 1     # [win]
-    - if not exist %LIBRARY_INC%\\ObjCryst\\Crystal.h exit 1            # [win]
-    - if not exist %LIBRARY_INC%\\Quirks\\VFNDebug.h exit 1             # [win]
-    - if not exist %LIBRARY_INC%\\RefinableObj\\RefinableObj.h exit 1   # [win]
+    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}                                 # [not win]
+    - test -f $PREFIX/include/ObjCryst/version.h                                  # [not win]
+    - test -f $PREFIX/include/ObjCryst/CrystVector/CrystVector.h                  # [not win]
+    - test -f $PREFIX/include/ObjCryst/ObjCryst/Crystal.h                         # [not win]
+    - test -f $PREFIX/include/ObjCryst/Quirks/VFNDebug.h                          # [not win]
+    - test -f $PREFIX/include/ObjCryst/RefinableObj/RefinableObj.h                # [not win]
+    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1                          # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1                      # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\CrystVector\\CrystVector.h exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\ObjCryst\\Crystal.h exit 1            # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\Quirks\\VFNDebug.h exit 1             # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\RefinableObj\\RefinableObj.h exit 1   # [win]
 
 about:
   home: https://github.com/diffpy/libobjcryst/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,9 @@ package:
 
 source:
   git_url: https://github.com/diffpy/libobjcryst.git
-  git_rev: 2b63b02c39d85be51a8b6f84eb30ce8c3eebc0c8
+  git_rev: v2024.2.1
+  git_depth: 20
+# We need the objcryst submodule, so prefer using a git source
 #  fn: {{ name }}-{{ version }}.tar.gz
 #  url: https://github.com/diffpy/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
 #  sha256: 3878a127cd939a1025e95a90713b59d85213eeb5cc6882a493d4670b0e81bc48
@@ -28,18 +30,18 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}                     # [not win]
-    - test -f $PREFIX/include/ObjCryst/version.h                      # [not win]
-    - test -f $PREFIX/include/ObjCryst/CrystVector/CrystVector.h      # [not win]
-    - test -f $PREFIX/include/ObjCryst/ObjCryst/Crystal.h             # [not win]
-    - test -f $PREFIX/include/ObjCryst/Quirks/VFNDebug.h              # [not win]
-    - test -f $PREFIX/include/ObjCryst/RefinableObj/RefinableObj.h    # [not win]
-    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1              # [win]
-    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1          # [win]
-    - if not exist %LIBRARY_INC%\\CrystVector\\CrystVector.h exit 1   # [win]
-    - if not exist %LIBRARY_INC%\\ObjCryst\\Crystal.h exit 1          # [win]
-    - if not exist %LIBRARY_INC%\\Quirks\\VFNDebug.h exit 1           # [win]
-    - if not exist %LIBRARY_INC%\\RefinableObj\\RefinableObj.h exit 1 # [win]
+    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}                       # [not win]
+    - test -f $PREFIX/include/ObjCryst/version.h                        # [not win]
+    - test -f $PREFIX/include/ObjCryst/CrystVector/CrystVector.h        # [not win]
+    - test -f $PREFIX/include/ObjCryst/ObjCryst/Crystal.h               # [not win]
+    - test -f $PREFIX/include/ObjCryst/Quirks/VFNDebug.h                # [not win]
+    - test -f $PREFIX/include/ObjCryst/RefinableObj/RefinableObj.h      # [not win]
+    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1                # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1            # [win]
+    - if not exist %LIBRARY_INC%\\CrystVector\\CrystVector.h exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\Crystal.h exit 1            # [win]
+    - if not exist %LIBRARY_INC%\\Quirks\\VFNDebug.h exit 1             # [win]
+    - if not exist %LIBRARY_INC%\\RefinableObj\\RefinableObj.h exit 1   # [win]
 
 about:
   home: https://github.com/diffpy/libobjcryst/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/diffpy/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3878a127cd939a1025e95a90713b59d85213eeb5cc6882a493d4670b0e81bc48
+  git_url: https://github.com/diffpy/libobjcryst.git
+  git_rev: 2b63b02c39d85be51a8b6f84eb30ce8c3eebc0c8
+#  fn: {{ name }}-{{ version }}.tar.gz
+#  url: https://github.com/diffpy/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+#  sha256: 3878a127cd939a1025e95a90713b59d85213eeb5cc6882a493d4670b0e81bc48
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libobjcryst', max_pin='x.x') }}
 
@@ -26,10 +28,18 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}             # [not win]
-    - test -f $PREFIX/include/ObjCryst/version.h              # [not win]
-    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1      # [win]
-    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1  # [win]
+    - test -f $PREFIX/lib/libObjCryst${SHLIB_EXT}                     # [not win]
+    - test -f $PREFIX/include/ObjCryst/version.h                      # [not win]
+    - test -f $PREFIX/include/ObjCryst/CrystVector/CrystVector.h      # [not win]
+    - test -f $PREFIX/include/ObjCryst/ObjCryst/Crystal.h             # [not win]
+    - test -f $PREFIX/include/ObjCryst/Quirks/VFNDebug.h              # [not win]
+    - test -f $PREFIX/include/ObjCryst/RefinableObj/RefinableObj.h    # [not win]
+    - if not exist %LIBRARY_LIB%\\libObjCryst.lib exit 1              # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\version.h exit 1          # [win]
+    - if not exist %LIBRARY_INC%\\CrystVector\\CrystVector.h exit 1   # [win]
+    - if not exist %LIBRARY_INC%\\ObjCryst\\Crystal.h exit 1          # [win]
+    - if not exist %LIBRARY_INC%\\Quirks\\VFNDebug.h exit 1           # [win]
+    - if not exist %LIBRARY_INC%\\RefinableObj\\RefinableObj.h exit 1 # [win]
 
 about:
   home: https://github.com/diffpy/libobjcryst/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In the 2024.2.1 builds, [the ObjCryst include files are not installed and thus included in the package](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1023945&view=logs&j=ced5d8de-8227-5f3f-33a1-45cf1592c45a&t=f7bcb349-6dca-53ba-d88d-1d9963e119ba&l=1242) on all platforms, which is strange as it works locally (either direct install of libobcryst, or using `build-locally.py` on the feedstock).